### PR TITLE
chore: fix test coverrage

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	get         string = "get"
 	add         string = "add"
-	delete      string = "delete"
+	del         string = "del"
 	help        string = "help"
 	version     string = "version"
 	update      string = "update"
@@ -215,36 +215,36 @@ func TestRootCmd(t *testing.T) {
 			}
 
 		// ? Test delete argument
-		case delete:
+		case del:
 			tests := tts{
 				{
-					name: delete + " without args",
-					args: []string{delete},
+					name: del + " without args",
+					args: []string{del},
 					fail: true, // Should fail because no args
 				},
 				{
-					name: delete + " with a whatever flag",
-					args: []string{delete, "--whatever"},
+					name: del + " with a whatever flag",
+					args: []string{del, "--whatever"},
 					fail: true, // Should fail because flag no exist
 				},
 				{
-					name: delete + " a bucket",
-					args: []string{delete, "s3", "whatever", "whatever-time"},
+					name: del + " a bucket",
+					args: []string{del, "s3", "whatever", "whatever-time"},
 					fail: false,
 				},
 				{
-					name: delete + " a publicip",
-					args: []string{delete, "publicip", "whatever"},
+					name: del + " a publicip",
+					args: []string{del, "publicip", "whatever"},
 					fail: true,
 				},
 				{
-					name: delete + " an edgegateway",
-					args: []string{delete, "edgegateway", "tn01e02ocb0006205spt104"},
+					name: del + " an edgegateway",
+					args: []string{del, "edgegateway", "tn01e02ocb0006205spt104"},
 					fail: false,
 				},
 				{
-					name: delete + " a vdc",
-					args: []string{delete, "vdc", "whatever", "whatever-time"},
+					name: del + " a vdc",
+					args: []string{del, "vdc", "whatever", "whatever-time"},
 					fail: false,
 				},
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Cloud Avenue CLI !
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] If Needed add a changelog file
- [x] Write or modify coverage tests
- [x] Run make generate to ensure the doc was updated properly

### How has this code been coverage and tested
```
go test -coverprofile=coverage.out ./cmd/... && go tool cover -func=coverage.out

coverage: 69.7% of statements
ok      github.com/orange-cloudavenue/cloudavenue-cli/cmd       263.564s        coverage: 69.7% of statements
github.com/orange-cloudavenue/cloudavenue-cli/cmd/add.go:27:            init                    65.2%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/del.go:31:            init                    100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/get.go:45:            init                    100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root.go:16:           Execute                 50.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root.go:31:           NewRootCmd              100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root.go:36:           init                    100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root_client.go:16:    initConfig              47.8%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root_client.go:60:    initClient              75.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root_global.go:67:    stringToTypeFormat      75.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/root_global.go:79:    timeTrack               100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/update.go:17:         init                    100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/version.go:5:         init                    100.0%
github.com/orange-cloudavenue/cloudavenue-cli/cmd/version.go:10:        versionCmd              100.0%
total:                                                                  (statements)            71.9%
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->